### PR TITLE
vertica_python.connect should use kwargs

### DIFF
--- a/vertica_stats.py
+++ b/vertica_stats.py
@@ -67,7 +67,7 @@ conn_info = {'host': options.host,
              'database': options.database}
 
 # simple connection, with manual close
-connection = vertica_python.connect(conn_info)
+connection = vertica_python.connect(**conn_info)
 cur = connection.cursor()
 
 # find the right metric


### PR DESCRIPTION
vertica_python.connect doesn't receive a dictionary object containing the connection properties but rather kwargs should be set with the dictionary conn_info instead.
